### PR TITLE
Add comprehensive test reports - 3,323 total tests

### DIFF
--- a/embedding_framework_report.json
+++ b/embedding_framework_report.json
@@ -1,0 +1,259 @@
+{
+  "adapter": {
+    "endpoint_set": false,
+    "spec": "tests.mock.mock_embedding_adapter:MockEmbeddingAdapter"
+  },
+  "duration_s": 22.281597137451172,
+  "generated_at_epoch_s": 1770773137,
+  "platinum_certified": true,
+  "policy": {
+    "max_failures": null,
+    "strict": false
+  },
+  "protocols": {
+    "embedding": {
+      "collected_total": 0,
+      "display_name": "Embedding Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 38,
+        "gold": 75,
+        "silver": 60
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "embedding_frameworks": {
+      "collected_total": 418,
+      "display_name": "Embedding Framework Adapters V1.0",
+      "level": "Gold",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 418,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 60,
+        "gold": 121,
+        "silver": 97
+      },
+      "scored_passed": 418,
+      "scored_total": 418,
+      "tests_needed_to_next_level": 0
+    },
+    "golden": {
+      "collected_total": 0,
+      "display_name": "CORPUS Golden Wire Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 39,
+        "gold": 78,
+        "silver": 62
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "graph": {
+      "collected_total": 0,
+      "display_name": "Graph Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 34,
+        "gold": 68,
+        "silver": 54
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "graph_frameworks": {
+      "collected_total": 0,
+      "display_name": "Graph Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 92,
+        "gold": 184,
+        "silver": 147
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "llm": {
+      "collected_total": 0,
+      "display_name": "LLM Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 56,
+        "gold": 111,
+        "silver": 89
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "llm_frameworks": {
+      "collected_total": 0,
+      "display_name": "LLM Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 75,
+        "gold": 150,
+        "silver": 120
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "schema": {
+      "collected_total": 0,
+      "display_name": "CORPUS Schema Conformance Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 7,
+        "gold": 13,
+        "silver": 10
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "vector": {
+      "collected_total": 0,
+      "display_name": "Vector Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 36,
+        "gold": 73,
+        "silver": 58
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "vector_frameworks": {
+      "collected_total": 0,
+      "display_name": "Vector Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 65,
+        "gold": 130,
+        "silver": 104
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "wire": {
+      "collected_total": 0,
+      "display_name": "Wire Request Conformance Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 37,
+        "gold": 73,
+        "silver": 58
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    }
+  },
+  "version": 2,
+  "why_not_platinum": {
+    "blocked": false,
+    "reasons": [],
+    "strict": false,
+    "totals": {
+      "error": 0,
+      "failed": 0,
+      "skipped": 0,
+      "xfailed": 0,
+      "xpassed": 0
+    }
+  }
+}

--- a/embedding_report.json
+++ b/embedding_report.json
@@ -1,0 +1,259 @@
+{
+  "adapter": {
+    "endpoint_set": false,
+    "spec": "tests.mock.mock_embedding_adapter:MockEmbeddingAdapter"
+  },
+  "duration_s": 3.097240924835205,
+  "generated_at_epoch_s": 1770772076,
+  "platinum_certified": true,
+  "policy": {
+    "max_failures": null,
+    "strict": false
+  },
+  "protocols": {
+    "embedding": {
+      "collected_total": 135,
+      "display_name": "Embedding Protocol V1.0",
+      "level": "Gold",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 135,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 38,
+        "gold": 75,
+        "silver": 60
+      },
+      "scored_passed": 135,
+      "scored_total": 135,
+      "tests_needed_to_next_level": 0
+    },
+    "embedding_frameworks": {
+      "collected_total": 0,
+      "display_name": "Embedding Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 60,
+        "gold": 121,
+        "silver": 97
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "golden": {
+      "collected_total": 0,
+      "display_name": "CORPUS Golden Wire Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 39,
+        "gold": 78,
+        "silver": 62
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "graph": {
+      "collected_total": 0,
+      "display_name": "Graph Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 34,
+        "gold": 68,
+        "silver": 54
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "graph_frameworks": {
+      "collected_total": 0,
+      "display_name": "Graph Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 92,
+        "gold": 184,
+        "silver": 147
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "llm": {
+      "collected_total": 0,
+      "display_name": "LLM Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 56,
+        "gold": 111,
+        "silver": 89
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "llm_frameworks": {
+      "collected_total": 0,
+      "display_name": "LLM Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 75,
+        "gold": 150,
+        "silver": 120
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "schema": {
+      "collected_total": 0,
+      "display_name": "CORPUS Schema Conformance Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 7,
+        "gold": 13,
+        "silver": 10
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "vector": {
+      "collected_total": 0,
+      "display_name": "Vector Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 36,
+        "gold": 73,
+        "silver": 58
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "vector_frameworks": {
+      "collected_total": 0,
+      "display_name": "Vector Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 65,
+        "gold": 130,
+        "silver": 104
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "wire": {
+      "collected_total": 0,
+      "display_name": "Wire Request Conformance Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 37,
+        "gold": 73,
+        "silver": 58
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    }
+  },
+  "version": 2,
+  "why_not_platinum": {
+    "blocked": false,
+    "reasons": [],
+    "strict": false,
+    "totals": {
+      "error": 0,
+      "failed": 0,
+      "skipped": 0,
+      "xfailed": 0,
+      "xpassed": 0
+    }
+  }
+}

--- a/graph_framework_report.json
+++ b/graph_framework_report.json
@@ -1,0 +1,259 @@
+{
+  "adapter": {
+    "endpoint_set": false,
+    "spec": "tests.mock.mock_graph_adapter:MockGraphAdapter"
+  },
+  "duration_s": 20.079835176467896,
+  "generated_at_epoch_s": 1770773099,
+  "platinum_certified": true,
+  "policy": {
+    "max_failures": null,
+    "strict": false
+  },
+  "protocols": {
+    "embedding": {
+      "collected_total": 0,
+      "display_name": "Embedding Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 38,
+        "gold": 75,
+        "silver": 60
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "embedding_frameworks": {
+      "collected_total": 0,
+      "display_name": "Embedding Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 60,
+        "gold": 121,
+        "silver": 97
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "golden": {
+      "collected_total": 0,
+      "display_name": "CORPUS Golden Wire Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 39,
+        "gold": 78,
+        "silver": 62
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "graph": {
+      "collected_total": 0,
+      "display_name": "Graph Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 34,
+        "gold": 68,
+        "silver": 54
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "graph_frameworks": {
+      "collected_total": 574,
+      "display_name": "Graph Framework Adapters V1.0",
+      "level": "Gold",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 574,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 92,
+        "gold": 184,
+        "silver": 147
+      },
+      "scored_passed": 574,
+      "scored_total": 574,
+      "tests_needed_to_next_level": 0
+    },
+    "llm": {
+      "collected_total": 0,
+      "display_name": "LLM Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 56,
+        "gold": 111,
+        "silver": 89
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "llm_frameworks": {
+      "collected_total": 0,
+      "display_name": "LLM Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 75,
+        "gold": 150,
+        "silver": 120
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "schema": {
+      "collected_total": 0,
+      "display_name": "CORPUS Schema Conformance Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 7,
+        "gold": 13,
+        "silver": 10
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "vector": {
+      "collected_total": 0,
+      "display_name": "Vector Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 36,
+        "gold": 73,
+        "silver": 58
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "vector_frameworks": {
+      "collected_total": 0,
+      "display_name": "Vector Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 65,
+        "gold": 130,
+        "silver": 104
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "wire": {
+      "collected_total": 0,
+      "display_name": "Wire Request Conformance Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 37,
+        "gold": 73,
+        "silver": 58
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    }
+  },
+  "version": 2,
+  "why_not_platinum": {
+    "blocked": false,
+    "reasons": [],
+    "strict": false,
+    "totals": {
+      "error": 0,
+      "failed": 0,
+      "skipped": 0,
+      "xfailed": 0,
+      "xpassed": 0
+    }
+  }
+}

--- a/graph_report.json
+++ b/graph_report.json
@@ -1,0 +1,259 @@
+{
+  "adapter": {
+    "endpoint_set": false,
+    "spec": "tests.mock.mock_graph_adapter:MockGraphAdapter"
+  },
+  "duration_s": 0.7736811637878418,
+  "generated_at_epoch_s": 1770772071,
+  "platinum_certified": true,
+  "policy": {
+    "max_failures": null,
+    "strict": false
+  },
+  "protocols": {
+    "embedding": {
+      "collected_total": 0,
+      "display_name": "Embedding Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 38,
+        "gold": 75,
+        "silver": 60
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "embedding_frameworks": {
+      "collected_total": 0,
+      "display_name": "Embedding Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 60,
+        "gold": 121,
+        "silver": 97
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "golden": {
+      "collected_total": 0,
+      "display_name": "CORPUS Golden Wire Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 39,
+        "gold": 78,
+        "silver": 62
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "graph": {
+      "collected_total": 99,
+      "display_name": "Graph Protocol V1.0",
+      "level": "Gold",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 99,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 34,
+        "gold": 68,
+        "silver": 54
+      },
+      "scored_passed": 99,
+      "scored_total": 99,
+      "tests_needed_to_next_level": 0
+    },
+    "graph_frameworks": {
+      "collected_total": 0,
+      "display_name": "Graph Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 92,
+        "gold": 184,
+        "silver": 147
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "llm": {
+      "collected_total": 0,
+      "display_name": "LLM Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 56,
+        "gold": 111,
+        "silver": 89
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "llm_frameworks": {
+      "collected_total": 0,
+      "display_name": "LLM Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 75,
+        "gold": 150,
+        "silver": 120
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "schema": {
+      "collected_total": 0,
+      "display_name": "CORPUS Schema Conformance Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 7,
+        "gold": 13,
+        "silver": 10
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "vector": {
+      "collected_total": 0,
+      "display_name": "Vector Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 36,
+        "gold": 73,
+        "silver": 58
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "vector_frameworks": {
+      "collected_total": 0,
+      "display_name": "Vector Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 65,
+        "gold": 130,
+        "silver": 104
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "wire": {
+      "collected_total": 0,
+      "display_name": "Wire Request Conformance Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 37,
+        "gold": 73,
+        "silver": 58
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    }
+  },
+  "version": 2,
+  "why_not_platinum": {
+    "blocked": false,
+    "reasons": [],
+    "strict": false,
+    "totals": {
+      "error": 0,
+      "failed": 0,
+      "skipped": 0,
+      "xfailed": 0,
+      "xpassed": 0
+    }
+  }
+}

--- a/llm_framework_report.json
+++ b/llm_framework_report.json
@@ -1,0 +1,259 @@
+{
+  "adapter": {
+    "endpoint_set": false,
+    "spec": "tests.mock.mock_llm_adapter:MockLLMAdapter"
+  },
+  "duration_s": 19.353473901748657,
+  "generated_at_epoch_s": 1770773172,
+  "platinum_certified": true,
+  "policy": {
+    "max_failures": null,
+    "strict": false
+  },
+  "protocols": {
+    "embedding": {
+      "collected_total": 0,
+      "display_name": "Embedding Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 38,
+        "gold": 75,
+        "silver": 60
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "embedding_frameworks": {
+      "collected_total": 0,
+      "display_name": "Embedding Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 60,
+        "gold": 121,
+        "silver": 97
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "golden": {
+      "collected_total": 0,
+      "display_name": "CORPUS Golden Wire Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 39,
+        "gold": 78,
+        "silver": 62
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "graph": {
+      "collected_total": 0,
+      "display_name": "Graph Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 34,
+        "gold": 68,
+        "silver": 54
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "graph_frameworks": {
+      "collected_total": 0,
+      "display_name": "Graph Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 92,
+        "gold": 184,
+        "silver": 147
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "llm": {
+      "collected_total": 0,
+      "display_name": "LLM Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 56,
+        "gold": 111,
+        "silver": 89
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "llm_frameworks": {
+      "collected_total": 624,
+      "display_name": "LLM Framework Adapters V1.0",
+      "level": "Gold",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 624,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 75,
+        "gold": 150,
+        "silver": 120
+      },
+      "scored_passed": 624,
+      "scored_total": 624,
+      "tests_needed_to_next_level": 0
+    },
+    "schema": {
+      "collected_total": 0,
+      "display_name": "CORPUS Schema Conformance Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 7,
+        "gold": 13,
+        "silver": 10
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "vector": {
+      "collected_total": 0,
+      "display_name": "Vector Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 36,
+        "gold": 73,
+        "silver": 58
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "vector_frameworks": {
+      "collected_total": 0,
+      "display_name": "Vector Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 65,
+        "gold": 130,
+        "silver": 104
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "wire": {
+      "collected_total": 0,
+      "display_name": "Wire Request Conformance Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 37,
+        "gold": 73,
+        "silver": 58
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    }
+  },
+  "version": 2,
+  "why_not_platinum": {
+    "blocked": false,
+    "reasons": [],
+    "strict": false,
+    "totals": {
+      "error": 0,
+      "failed": 0,
+      "skipped": 0,
+      "xfailed": 0,
+      "xpassed": 0
+    }
+  }
+}

--- a/llm_report.json
+++ b/llm_report.json
@@ -1,0 +1,259 @@
+{
+  "adapter": {
+    "endpoint_set": false,
+    "spec": "tests.mock.mock_llm_adapter:MockLLMAdapter"
+  },
+  "duration_s": 4.016133069992065,
+  "generated_at_epoch_s": 1770772064,
+  "platinum_certified": true,
+  "policy": {
+    "max_failures": null,
+    "strict": false
+  },
+  "protocols": {
+    "embedding": {
+      "collected_total": 0,
+      "display_name": "Embedding Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 38,
+        "gold": 75,
+        "silver": 60
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "embedding_frameworks": {
+      "collected_total": 0,
+      "display_name": "Embedding Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 60,
+        "gold": 121,
+        "silver": 97
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "golden": {
+      "collected_total": 0,
+      "display_name": "CORPUS Golden Wire Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 39,
+        "gold": 78,
+        "silver": 62
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "graph": {
+      "collected_total": 0,
+      "display_name": "Graph Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 34,
+        "gold": 68,
+        "silver": 54
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "graph_frameworks": {
+      "collected_total": 0,
+      "display_name": "Graph Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 92,
+        "gold": 184,
+        "silver": 147
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "llm": {
+      "collected_total": 132,
+      "display_name": "LLM Protocol V1.0",
+      "level": "Gold",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 132,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 56,
+        "gold": 111,
+        "silver": 89
+      },
+      "scored_passed": 132,
+      "scored_total": 132,
+      "tests_needed_to_next_level": 0
+    },
+    "llm_frameworks": {
+      "collected_total": 0,
+      "display_name": "LLM Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 75,
+        "gold": 150,
+        "silver": 120
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "schema": {
+      "collected_total": 0,
+      "display_name": "CORPUS Schema Conformance Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 7,
+        "gold": 13,
+        "silver": 10
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "vector": {
+      "collected_total": 0,
+      "display_name": "Vector Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 36,
+        "gold": 73,
+        "silver": 58
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "vector_frameworks": {
+      "collected_total": 0,
+      "display_name": "Vector Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 65,
+        "gold": 130,
+        "silver": 104
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "wire": {
+      "collected_total": 0,
+      "display_name": "Wire Request Conformance Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 37,
+        "gold": 73,
+        "silver": 58
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    }
+  },
+  "version": 2,
+  "why_not_platinum": {
+    "blocked": false,
+    "reasons": [],
+    "strict": false,
+    "totals": {
+      "error": 0,
+      "failed": 0,
+      "skipped": 0,
+      "xfailed": 0,
+      "xpassed": 0
+    }
+  }
+}

--- a/schema_report.json
+++ b/schema_report.json
@@ -1,0 +1,259 @@
+{
+  "adapter": {
+    "endpoint_set": false,
+    "spec": "tests.mock.mock_llm_adapter:MockLLMAdapter"
+  },
+  "duration_s": 1.449052095413208,
+  "generated_at_epoch_s": 1770772213,
+  "platinum_certified": true,
+  "policy": {
+    "max_failures": null,
+    "strict": false
+  },
+  "protocols": {
+    "embedding": {
+      "collected_total": 0,
+      "display_name": "Embedding Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 38,
+        "gold": 75,
+        "silver": 60
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "embedding_frameworks": {
+      "collected_total": 0,
+      "display_name": "Embedding Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 60,
+        "gold": 121,
+        "silver": 97
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "golden": {
+      "collected_total": 0,
+      "display_name": "CORPUS Golden Wire Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 39,
+        "gold": 78,
+        "silver": 62
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "graph": {
+      "collected_total": 0,
+      "display_name": "Graph Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 34,
+        "gold": 68,
+        "silver": 54
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "graph_frameworks": {
+      "collected_total": 0,
+      "display_name": "Graph Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 92,
+        "gold": 184,
+        "silver": 147
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "llm": {
+      "collected_total": 0,
+      "display_name": "LLM Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 56,
+        "gold": 111,
+        "silver": 89
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "llm_frameworks": {
+      "collected_total": 0,
+      "display_name": "LLM Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 75,
+        "gold": 150,
+        "silver": 120
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "schema": {
+      "collected_total": 199,
+      "display_name": "CORPUS Schema Conformance Suite",
+      "level": "Gold",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 199,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 7,
+        "gold": 13,
+        "silver": 10
+      },
+      "scored_passed": 199,
+      "scored_total": 199,
+      "tests_needed_to_next_level": 0
+    },
+    "vector": {
+      "collected_total": 0,
+      "display_name": "Vector Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 36,
+        "gold": 73,
+        "silver": 58
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "vector_frameworks": {
+      "collected_total": 0,
+      "display_name": "Vector Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 65,
+        "gold": 130,
+        "silver": 104
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "wire": {
+      "collected_total": 0,
+      "display_name": "Wire Request Conformance Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 37,
+        "gold": 73,
+        "silver": 58
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    }
+  },
+  "version": 2,
+  "why_not_platinum": {
+    "blocked": false,
+    "reasons": [],
+    "strict": false,
+    "totals": {
+      "error": 0,
+      "failed": 0,
+      "skipped": 0,
+      "xfailed": 0,
+      "xpassed": 0
+    }
+  }
+}

--- a/vector_framework_report.json
+++ b/vector_framework_report.json
@@ -1,0 +1,259 @@
+{
+  "adapter": {
+    "endpoint_set": false,
+    "spec": "tests.mock.mock_vector_adapter:MockVectorAdapter"
+  },
+  "duration_s": 17.5838520526886,
+  "generated_at_epoch_s": 1770773601,
+  "platinum_certified": true,
+  "policy": {
+    "max_failures": null,
+    "strict": false
+  },
+  "protocols": {
+    "embedding": {
+      "collected_total": 0,
+      "display_name": "Embedding Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 38,
+        "gold": 75,
+        "silver": 60
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "embedding_frameworks": {
+      "collected_total": 0,
+      "display_name": "Embedding Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 60,
+        "gold": 121,
+        "silver": 97
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "golden": {
+      "collected_total": 0,
+      "display_name": "CORPUS Golden Wire Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 39,
+        "gold": 78,
+        "silver": 62
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "graph": {
+      "collected_total": 0,
+      "display_name": "Graph Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 34,
+        "gold": 68,
+        "silver": 54
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "graph_frameworks": {
+      "collected_total": 0,
+      "display_name": "Graph Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 92,
+        "gold": 184,
+        "silver": 147
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "llm": {
+      "collected_total": 0,
+      "display_name": "LLM Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 56,
+        "gold": 111,
+        "silver": 89
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "llm_frameworks": {
+      "collected_total": 0,
+      "display_name": "LLM Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 75,
+        "gold": 150,
+        "silver": 120
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "schema": {
+      "collected_total": 0,
+      "display_name": "CORPUS Schema Conformance Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 7,
+        "gold": 13,
+        "silver": 10
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "vector": {
+      "collected_total": 0,
+      "display_name": "Vector Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 36,
+        "gold": 73,
+        "silver": 58
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "vector_frameworks": {
+      "collected_total": 958,
+      "display_name": "Vector Framework Adapters V1.0",
+      "level": "Gold",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 958,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 65,
+        "gold": 130,
+        "silver": 104
+      },
+      "scored_passed": 958,
+      "scored_total": 958,
+      "tests_needed_to_next_level": 0
+    },
+    "wire": {
+      "collected_total": 0,
+      "display_name": "Wire Request Conformance Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 37,
+        "gold": 73,
+        "silver": 58
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    }
+  },
+  "version": 2,
+  "why_not_platinum": {
+    "blocked": false,
+    "reasons": [],
+    "strict": false,
+    "totals": {
+      "error": 0,
+      "failed": 0,
+      "skipped": 0,
+      "xfailed": 0,
+      "xpassed": 0
+    }
+  }
+}

--- a/vector_report.json
+++ b/vector_report.json
@@ -1,0 +1,259 @@
+{
+  "adapter": {
+    "endpoint_set": false,
+    "spec": "tests.mock.mock_vector_adapter:MockVectorAdapter"
+  },
+  "duration_s": 3.5565261840820312,
+  "generated_at_epoch_s": 1770772069,
+  "platinum_certified": true,
+  "policy": {
+    "max_failures": null,
+    "strict": false
+  },
+  "protocols": {
+    "embedding": {
+      "collected_total": 0,
+      "display_name": "Embedding Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 38,
+        "gold": 75,
+        "silver": 60
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "embedding_frameworks": {
+      "collected_total": 0,
+      "display_name": "Embedding Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 60,
+        "gold": 121,
+        "silver": 97
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "golden": {
+      "collected_total": 0,
+      "display_name": "CORPUS Golden Wire Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 39,
+        "gold": 78,
+        "silver": 62
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "graph": {
+      "collected_total": 0,
+      "display_name": "Graph Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 34,
+        "gold": 68,
+        "silver": 54
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "graph_frameworks": {
+      "collected_total": 0,
+      "display_name": "Graph Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 92,
+        "gold": 184,
+        "silver": 147
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "llm": {
+      "collected_total": 0,
+      "display_name": "LLM Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 56,
+        "gold": 111,
+        "silver": 89
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "llm_frameworks": {
+      "collected_total": 0,
+      "display_name": "LLM Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 75,
+        "gold": 150,
+        "silver": 120
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "schema": {
+      "collected_total": 0,
+      "display_name": "CORPUS Schema Conformance Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 7,
+        "gold": 13,
+        "silver": 10
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "vector": {
+      "collected_total": 108,
+      "display_name": "Vector Protocol V1.0",
+      "level": "Gold",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 108,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 36,
+        "gold": 73,
+        "silver": 58
+      },
+      "scored_passed": 108,
+      "scored_total": 108,
+      "tests_needed_to_next_level": 0
+    },
+    "vector_frameworks": {
+      "collected_total": 0,
+      "display_name": "Vector Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 65,
+        "gold": 130,
+        "silver": 104
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "wire": {
+      "collected_total": 0,
+      "display_name": "Wire Request Conformance Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 37,
+        "gold": 73,
+        "silver": 58
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    }
+  },
+  "version": 2,
+  "why_not_platinum": {
+    "blocked": false,
+    "reasons": [],
+    "strict": false,
+    "totals": {
+      "error": 0,
+      "failed": 0,
+      "skipped": 0,
+      "xfailed": 0,
+      "xpassed": 0
+    }
+  }
+}

--- a/wire_report.json
+++ b/wire_report.json
@@ -1,0 +1,259 @@
+{
+  "adapter": {
+    "endpoint_set": false,
+    "spec": "tests.mock.mock_wire_adapter:WireAdapter"
+  },
+  "duration_s": 0.4989502429962158,
+  "generated_at_epoch_s": 1770772157,
+  "platinum_certified": true,
+  "policy": {
+    "max_failures": null,
+    "strict": false
+  },
+  "protocols": {
+    "embedding": {
+      "collected_total": 0,
+      "display_name": "Embedding Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 38,
+        "gold": 75,
+        "silver": 60
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "embedding_frameworks": {
+      "collected_total": 0,
+      "display_name": "Embedding Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 60,
+        "gold": 121,
+        "silver": 97
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "golden": {
+      "collected_total": 0,
+      "display_name": "CORPUS Golden Wire Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 39,
+        "gold": 78,
+        "silver": 62
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "graph": {
+      "collected_total": 0,
+      "display_name": "Graph Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 34,
+        "gold": 68,
+        "silver": 54
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "graph_frameworks": {
+      "collected_total": 0,
+      "display_name": "Graph Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 92,
+        "gold": 184,
+        "silver": 147
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "llm": {
+      "collected_total": 0,
+      "display_name": "LLM Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 56,
+        "gold": 111,
+        "silver": 89
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "llm_frameworks": {
+      "collected_total": 0,
+      "display_name": "LLM Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 75,
+        "gold": 150,
+        "silver": 120
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "schema": {
+      "collected_total": 0,
+      "display_name": "CORPUS Schema Conformance Suite",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 7,
+        "gold": 13,
+        "silver": 10
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "vector": {
+      "collected_total": 0,
+      "display_name": "Vector Protocol V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 36,
+        "gold": 73,
+        "silver": 58
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "vector_frameworks": {
+      "collected_total": 0,
+      "display_name": "Vector Framework Adapters V1.0",
+      "level": "No Tests Scored",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 65,
+        "gold": 130,
+        "silver": 104
+      },
+      "scored_passed": 0,
+      "scored_total": 0,
+      "tests_needed_to_next_level": 0
+    },
+    "wire": {
+      "collected_total": 76,
+      "display_name": "Wire Request Conformance Suite",
+      "level": "Gold",
+      "outcomes": {
+        "error": 0,
+        "failed": 0,
+        "passed": 76,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "reference_levels": {
+        "development": 37,
+        "gold": 73,
+        "silver": 58
+      },
+      "scored_passed": 76,
+      "scored_total": 76,
+      "tests_needed_to_next_level": 0
+    }
+  },
+  "version": 2,
+  "why_not_platinum": {
+    "blocked": false,
+    "reasons": [],
+    "strict": false,
+    "totals": {
+      "error": 0,
+      "failed": 0,
+      "skipped": 0,
+      "xfailed": 0,
+      "xpassed": 0
+    }
+  }
+}


### PR DESCRIPTION
Core Protocol Tests (749 tests):
- embedding_report.json: 135 tests (Gold)
- graph_report.json: 99 tests (Gold)
- llm_report.json: 132 tests (Gold)
- vector_report.json: 108 tests (Gold)
- schema_report.json: 199 tests (Gold)
- wire_report.json: 76 tests (Gold)

Framework Adapter Tests (2,574 tests):
- embedding_framework_report.json: 418 tests (PLATINUM)
- graph_framework_report.json: 574 tests (PLATINUM)
- llm_framework_report.json: 624 tests (PLATINUM)
- vector_framework_report.json: 958 tests (PLATINUM)

All test suites achieved Gold or PLATINUM certification.